### PR TITLE
feat(ui): nginx static UI + /api proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:alpine
+# serve static UI from the spec's path
+COPY web/ /var/www/bmad/
+# nginx config with API proxy
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+# Nginx listens on port 80 by default

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  server_name _;
+  root /var/www/bmad;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    proxy_pass https://bmad.blackbirdn8n.xyz/api/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="vi">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>BMAD – Simple UI</title>
+  <style>
+    :root { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto; }
+    body { margin: 24px; max-width: 820px; }
+    .row { display: flex; gap: 8px; margin: 8px 0; }
+    label { min-width: 120px; font-weight: 600; }
+    textarea { width: 100%; min-height: 120px; padding: 10px; }
+    select, input, button { padding: 8px 10px; }
+    button { cursor: pointer; }
+    #result { white-space: pre-wrap; background:#fafafa; border:1px solid #eee; padding:12px; border-radius:8px; margin-top:16px; }
+
+    /* Nút + loader */
+    .btn { position: relative; display:inline-flex; align-items:center; gap:8px; }
+    .spinner {
+      display: inline-block; width: 16px; height: 16px; border: 2px solid #999; border-top-color: transparent;
+      border-radius: 50%; animation: spin 0.9s linear infinite; visibility: hidden;
+    }
+    .btn.loading .spinner { visibility: visible; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .muted { color:#666; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <!-- Simple UI for interacting with /api/ask -->
+  <h1>BMAD – Simple UI</h1>
+  <p class="muted">Demo gọi API /api/ask của BMAD. BE giữ nguyên, chỉ thêm UI tối giản.</p>
+
+  <div class="row">
+    <label for="pack">Pack</label>
+    <select id="pack">
+      <option value="bmad-problem-solver">bmad-problem-solver</option>
+      <option value="bmad-product-manager">bmad-product-manager</option>
+      <option value="bmad-market-researcher">bmad-market-researcher</option>
+    </select>
+  </div>
+  <div class="row">
+    <label for="agent">Agent</label>
+    <input id="agent" value="systems-thinker" />
+  </div>
+  <div class="row">
+    <label for="question">Câu hỏi</label>
+    <textarea id="question" placeholder="Nhập yêu cầu..."></textarea>
+  </div>
+  <div class="row">
+    <button id="askBtn" class="btn">
+      <span class="spinner" aria-hidden="true"></span>
+      <span id="btnText">Gọi Agent</span>
+    </button>
+  </div>
+
+  <div id="result"></div>
+
+  <script>
+    const btn = document.getElementById('askBtn');
+    const btnText = document.getElementById('btnText');
+    const result = document.getElementById('result');
+
+    async function ask() {
+      const pack = document.getElementById('pack').value.trim();
+      const agent = document.getElementById('agent').value.trim();
+      const question = document.getElementById('question').value.trim();
+      if (!question) { alert('Nhập câu hỏi'); return; }
+
+      btn.classList.add('loading'); btn.disabled = true; btnText.textContent = 'Đang xử lý...';
+      result.textContent = '';
+
+      try {
+        const res = await fetch('/api/ask', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pack, agent, question })
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || 'Lỗi gọi API');
+        result.textContent = data.answer || JSON.stringify(data, null, 2);
+      } catch (e) {
+        result.textContent = '❌ ' + e.message;
+      } finally {
+        btn.classList.remove('loading'); btn.disabled = false; btnText.textContent = 'Gọi Agent';
+      }
+    }
+    btn.addEventListener('click', ask);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve UI from /var/www/bmad using Nginx.
- Proxy /api/* to https://bmad.blackbirdn8n.xyz to reuse the existing backend.
- Lightweight PR checks only; full build+deploy happens on push to main.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run validate`
- `rg 'npm ci' -n` *(no matches)*
- `rg 'node src/server.js' -n` *(no matches)*

------
https://chatgpt.com/codex/tasks/task_e_68a1caead0f083308752f52256b44a92